### PR TITLE
update to v3.3.1 inorder to fix opentable/otj-etcd-embedded#4

### DIFF
--- a/download-etcd.sh
+++ b/download-etcd.sh
@@ -3,7 +3,7 @@
 
 shopt -s nullglob
 
-RELEASE=3.0.13
+RELEASE=3.3.1
 DEST=${1:-target/generated-resources/etcd}
 mkdir -p $DEST
 cd $DEST

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
   <artifactId>otj-etcd-embedded</artifactId>
   <name>otj-etcd-embedded</name>
   <packaging>jar</packaging>
-  <version>3.0.13-OT-2-SNAPSHOT</version>
+  <version>3.3.1-OT-3-SNAPSHOT</version>
   <description>Embedded ETCD server test library</description>
 
   <build>


### PR DESCRIPTION
Updating to the v3.3.1 release  fixes opentable/otj-etcd-embedded#4 segmentation fault produced on recent osx version.